### PR TITLE
Mod: add the saint maker forum as a default mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ The draft of the SaintMaker PWA. Will eventually function as the town square for
 The SaintMaker has the goal of being "moddable" in that you can create additional applications independent of it and link them back to it. However, we curate said applications.
 
 If you would like to create a mod for the SaintMaker then the steps for doing so are as follows:
-- Fork the SaintMaker core repository and build your new application on top of it https://github.com/Saint-Maker/prayer-book-template-a
-- To integrate your mod into our "marketplace" you'll need to create a branch off of the core repository; within it, run `yarn mod {your mod name} {your github user/organization name}`, this will generate a json file with a name like `Examen_cb0806151.json` in `src/mods` with a similar structure to the json included below. 
-- Once you've filled out that json with your mods details, your pull request is ready to submit.
-- We will then review your pull request and its corresponding codebase. If we believe it fits our audience (we probably will) we'll merge it; however, if it does not, users will still be able to add it as a custom mod.
+1. Fork the SaintMaker core repository and build your new application on top of it https://github.com/Saint-Maker/saint-maker-core
+2. To integrate your mod into our "marketplace" you'll need to create a branch off of the core repository; within it, run `yarn mod {your mod name (no spaces)} {your github user/organization name}`, this will generate a json file with a name like `Examen_cb0806151.json` in `src/mods` with a similar structure to the json included below. 
+3. Once you've filled out that json with your mods details, your pull request is ready to submit.
+4. We will then review your pull request and its corresponding codebase. If we believe it fits our audience (we probably will) we'll merge it; however, if it does not, users will still be able to add it as a custom mod.
 
 ```
 {

--- a/src/mods/saintmakerForum_cb0806151.json
+++ b/src/mods/saintmakerForum_cb0806151.json
@@ -1,0 +1,1 @@
+{"id":"OGVsyww1fJ4nUcgp","name":"SaintMaker Forum","issuesPageLink":"https://github.com/Saint-Maker/saint-maker-core/issues","path":"https://techpriesthub.xyz/fluxbb/index.php","description":"A forum where you can discuss SaintMaker stuff","isNative":false}

--- a/src/redux/slice/selectedModSlice.ts
+++ b/src/redux/slice/selectedModSlice.ts
@@ -3,7 +3,7 @@ import { createSlice, createAsyncThunk } from '@reduxjs/toolkit'
 import { sliceGet, sliceSet, sliceAdd } from '~slices/utils/sliceTools'
 import { idb } from '~utils/idb'
 
-const defaultState = ['piKfm_vdfBOEtu_X', 'eUD9oEbSHr8tEm4R']
+const defaultState = ['piKfm_vdfBOEtu_X', 'eUD9oEbSHr8tEm4R', 'OGVsyww1fJ4nUcgp']
 
 export const getSelectedMods = createAsyncThunk('selectedMod/getSelectedMods', async () => {
     return await sliceGet('selectedMods', defaultState)


### PR DESCRIPTION
# Description

The Saint Maker forum is a place to discuss stuff relating to the Saint Maker and its future development.

# Details
- mod repository: https://techpriesthub.xyz/fluxbb/index.php
- hosted using: yunohost on a local machine by Fr. David
- This PR also includes updates to outdated links in the readme and the adding of the SaintMaker forum as a default mod